### PR TITLE
feat: parse srt content

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Open Media Stack
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cue.go
+++ b/cue.go
@@ -1,0 +1,8 @@
+package subtitle
+
+type Cue struct {
+	Index int
+	Start Timecode
+	End   Timecode
+	Text  string
+}

--- a/srt/srt.go
+++ b/srt/srt.go
@@ -1,0 +1,88 @@
+package srt
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/OpenMediaStack/subtitle"
+)
+
+// Read reads SRT subtitles from an io.Reader and returns a slice of subtitle.Cue.
+func Read(r io.Reader) ([]subtitle.Cue, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	return parse(data)
+}
+
+// Open reads SRT subtitles from a file and returns a slice of subtitle.Cue.
+func Open(file string) ([]subtitle.Cue, error) {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	return parse(data)
+}
+
+// parse parses SRT subtitle data from a byte slice and returns a slice of subtitle.Cue.
+func parse(data []byte) ([]subtitle.Cue, error) {
+	b := bytes.NewReader(data)
+	s := bufio.NewScanner(b)
+
+	var state int
+	var cues []subtitle.Cue
+	var cue subtitle.Cue
+
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		switch state {
+		case 0:
+			if line == "" {
+				continue
+			}
+			index, err := strconv.Atoi(line)
+			if err != nil {
+				return nil, err
+			}
+			cue = subtitle.Cue{}
+			cue.Index = index
+			state = 1
+		case 1:
+			times := strings.Split(line, "-->")
+			start, err := subtitle.NewTimecode(times[0])
+			if err != nil {
+				return nil, err
+			}
+			cue.Start = start
+
+			end, err := subtitle.NewTimecode(times[1])
+			if err != nil {
+				return nil, err
+			}
+			cue.End = end
+			state = 2
+			continue
+		case 2:
+			if line == "" {
+				cues = append(cues, cue)
+				state = 0
+				continue
+			}
+			if cue.Text != "" {
+				cue.Text += "\n"
+			}
+			cue.Text += line
+
+		}
+
+	}
+	if state == 2 {
+		cues = append(cues, cue)
+	}
+	return cues, nil
+}

--- a/timecode.go
+++ b/timecode.go
@@ -1,0 +1,47 @@
+package subtitle
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Timecode struct {
+	Hour        int
+	Minute      int
+	Second      int
+	Millisecond int
+}
+
+func (t Timecode) String() string {
+	return fmt.Sprintf("%02d:%02d:%02d,%03d", t.Hour, t.Minute, t.Second, t.Millisecond)
+}
+
+// NewTimecode creates a new Timecode from a string in the format "HH:MM:SS,mmm".
+func NewTimecode(input string) (Timecode, error) {
+	splitted := strings.Split(strings.TrimSpace(input), ",")
+	ms, err := strconv.Atoi(splitted[1])
+	if err != nil {
+		return Timecode{}, err
+	}
+	times := strings.Split(splitted[0], ":")
+	hour, err := strconv.Atoi(times[0])
+	if err != nil {
+		return Timecode{}, err
+	}
+	minute, err := strconv.Atoi(times[1])
+	if err != nil {
+		return Timecode{}, err
+	}
+	second, err := strconv.Atoi(times[2])
+	if err != nil {
+		return Timecode{}, err
+	}
+
+	return Timecode{
+		Hour:        hour,
+		Minute:      minute,
+		Second:      second,
+		Millisecond: ms,
+	}, nil
+}


### PR DESCRIPTION
This pull request introduces a new subtitle parsing library with support for SRT files, along with the addition of a license for the project. The most important changes include the addition of a `Cue` struct and `Timecode` struct for representing subtitle data, as well as functions for reading and parsing SRT files.

### Licensing:
* Added an `MIT License` to the project, specifying terms for usage, distribution, and liability.

### Subtitle parsing library:
* **Core data structures**:
  * Introduced the `Cue` struct in `cue.go` to represent individual subtitle entries, including index, start time, end time, and text. 
  * Added the `Timecode` struct in `timecode.go` to represent timecodes in the "HH:MM:SS,mmm" format, along with a `String` method for formatting and a `NewTimecode` function for parsing. 

* **SRT file handling**:
  * Implemented `Read` and `Open` functions in `srt.go` for reading SRT subtitles from an `io.Reader` or a file, respectively. 
  * Added a `parse` function in `srt.go` to process SRT data and convert it into a slice of `Cue` structs, handling parsing of indices, timecodes, and multiline text. 